### PR TITLE
Add JSON to 2-space indent config in nvim_cshih

### DIFF
--- a/nvim_cshih/lua/config/autocmds.lua
+++ b/nvim_cshih/lua/config/autocmds.lua
@@ -15,7 +15,7 @@ vim.api.nvim_create_autocmd("FileType", {
 -- set tabspace to 2
 vim.api.nvim_create_autocmd("FileType", {
   group = augroup("tabspace_2"),
-  pattern = { "lua" },
+  pattern = { "lua", "json" },
   callback = function()
     vim.opt_local.shiftwidth = 2
     vim.opt_local.softtabstop = 2


### PR DESCRIPTION
## Summary
- Added `json` to the `tabspace_2` autocmd pattern in nvim_cshih config
- JSON files will now use 2-space indentation instead of default 4 spaces

## Test plan
- [ ] Open a JSON file in nvim_cshih
- [ ] Verify that new indentation uses 2 spaces